### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,7 @@ http {
     gzip_comp_level   1;
     gzip_http_version 1.1;
     gzip_min_length   10;
-    gzip_types        text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+    gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
     gzip_vary         on;
     gzip_proxied      any; # Compression for all requests.
     gzip_disable      "msie6";


### PR DESCRIPTION
If you don't have this change, your js files won't be zipped. I don't know why, because you already have an entry in mime.types file, but it doesn't work. You can compare the results at google pagespeed.
