### PR TITLE
Add config for shopware environment. Fixes issue #3.

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -123,6 +123,8 @@ location ~ \.php$ {
 
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param SHOPWARE_ENV    $shopware_env if_not_empty;
+    fastcgi_param ENV             $shopware_env if_not_empty; # BC for older SW versions
 
     fastcgi_buffers 8 16k;
     fastcgi_buffer_size 32k;

--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -9,6 +9,8 @@ server {
     access_log /var/log/nginx/example.com.access.log;
     error_log  /var/log/nginx/example.com.error.log;
 
+    set $shopware_env 'production'
+
     ## Server certificate and key.
     ssl_certificate      ssl/example.com.crt;
     ssl_certificate_key  ssl/example.com.key;


### PR DESCRIPTION
As requested in issue #3 I added a configuration variable that is passed to the fastcgi upstream.
This also means `set $shopware_env 'production'` is required now in the vhost config.
