### PR TITLE
Block direct access to ESDs

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -45,6 +45,14 @@ location ^~ /files/documents/ {
     deny all;
 }
 
+# Block direct access to ESDs, but allow the follwing download options:
+#  * 'PHP' (slow)
+#  * 'X-Accel' (optimized)
+# Also see http://wiki.shopware.com/ESD_detail_1116.html#Ab_Shopware_4.2.2
+location ^~ /files/552211cce724117c3178e3d22bec532ec/ {
+    internal;
+}
+
 # Breaks backend/media/ rewrite
 #
 #location ~ /(engine|files|templates|media)/ {


### PR DESCRIPTION
The `PHP` setting is the [default](https://github.com/shopware/shopware/blob/0449093fb28bfb7c65909c136e5a6af2f2cf8c64/_sql/migrations/231-update-redirectDownload-config-var.php#L16) anyways, so restricting direct access should not be a problem.
