### PR TITLE
Change FastCGI Param SCRIPT_FILENAME

### DIFF
--- a/fastcgi.conf
+++ b/fastcgi.conf
@@ -1,5 +1,5 @@
 
-fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+fastcgi_param  SCRIPT_FILENAME    $request_filename;
 fastcgi_param  QUERY_STRING       $query_string;
 fastcgi_param  REQUEST_METHOD     $request_method;
 fastcgi_param  CONTENT_TYPE       $content_type;


### PR DESCRIPTION
This change is needed otherwise the `index.php` will be printed int the installer like this: `<link rel="stylesheet" type="text/css" href="/recovery/install/index.php/../common/assets/styles/reset.css" media="all"/>` because of https://github.com/shopware/shopware/blob/5.2/recovery/common/src/Utils.php#L48-L68
