### PR TITLE
Fix media caching

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -41,15 +41,6 @@ location ^~ /files/documents/ {
     deny all;
 }
 
-## Fallback for old media paths
-location ^~ /media/ {
-    try_files $uri /shopware.php?controller=Media&action=fallback;
-}
-
-location ^~ /backend/media/ {
-    rewrite backend/media/(.*) /media/$1 redirect;
-}
-
 # Block direct access to ESDs, but allow the follwing download options:
 #  * 'PHP' (slow)
 #  * 'X-Accel' (optimized)
@@ -93,7 +84,7 @@ location / {
 
 
     ## All static files will be served directly.
-    location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|html)$ {
+    location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|html)$ {
         ## Defining rewrite rules
         rewrite files/documents/.* /engine last;
         rewrite backend/media/(.*) /media/$1 last;
@@ -114,7 +105,7 @@ location / {
 
         ## Fallback to shopware
         ## comment in if needed
-        #try_files $uri @shopware;
+        try_files $uri /shopware.php?controller=Media&action=fallback;
     }
 
     index shopware.php index.php;


### PR DESCRIPTION
Due the media fallback introduces in 5.1, we've killed all caching options defined later.

This combines both options.