### PR TITLE
enable http2

### DIFF
--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    listen 443 ssl;
+    listen 443 ssl http2;
 
     server_name example.com;
     root /var/www/example.com;


### PR DESCRIPTION
Add http2 protocol. Nginx is per default configured with http2 enabled in all latest versions so in my oppinion it makes sense to enable it.