### PR TITLE
Remove nested location rules

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -73,54 +73,53 @@ location /recovery/update/ {
     }
 }
 
+location ~* "^/themes/Frontend/Responsive/frontend/_public/vendors/fonts/open-sans-fontface/(?:.+)\.(?:ttf|eot|svg|woff)$" {
+    expires max;
+    add_header Cache-Control "public";
+    access_log off;
+    log_not_found off;
+}
+
+location ~* "^/themes/Frontend/Responsive/frontend/_public/src/fonts/(?:.+)\.(?:ttf|eot|svg|woff)$" {
+    expires max;
+    add_header Cache-Control "public";
+    access_log off;
+    log_not_found off;
+}
+
+location ~* "^/web/cache/(?:[0-9]{10})_(?:.+)\.(?:js|css)$" {
+    expires max;
+    add_header Cache-Control "public";
+    access_log off;
+    log_not_found off;
+}
+
+## All static files will be served directly.
+location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|html)$ {
+    ## Defining rewrite rules
+    rewrite files/documents/.* /engine last;
+    rewrite backend/media/(.*) /media/$1 last;
+
+    expires 1w;
+    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+
+    access_log off;
+    # The directive enables or disables messages in error_log about files not found on disk.
+    log_not_found off;
+
+    tcp_nodelay off;
+    ## Set the OS file cache.
+    open_file_cache max=3000 inactive=120s;
+    open_file_cache_valid 45s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors off;
+
+    ## Fallback to shopware
+    ## comment in if needed
+    try_files $uri /shopware.php?controller=Media&action=fallback;
+}
+
 location / {
-    location ~* "^/themes/Frontend/Responsive/frontend/_public/vendors/fonts/open-sans-fontface/(?:.+)\.(?:ttf|eot|svg|woff)$" {
-        expires max;
-        add_header Cache-Control "public";
-        access_log off;
-        log_not_found off;
-    }
-
-    location ~* "^/themes/Frontend/Responsive/frontend/_public/src/fonts/(?:.+)\.(?:ttf|eot|svg|woff)$" {
-        expires max;
-        add_header Cache-Control "public";
-        access_log off;
-        log_not_found off;
-    }
-
-    location ~* "^/web/cache/(?:[0-9]{10})_(?:.+)\.(?:js|css)$" {
-        expires max;
-        add_header Cache-Control "public";
-        access_log off;
-        log_not_found off;
-    }
-
-
-    ## All static files will be served directly.
-    location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|html)$ {
-        ## Defining rewrite rules
-        rewrite files/documents/.* /engine last;
-        rewrite backend/media/(.*) /media/$1 last;
-
-        expires 1w;
-        add_header Cache-Control "public, must-revalidate, proxy-revalidate";
-
-        access_log off;
-        # The directive enables or disables messages in error_log about files not found on disk.
-        log_not_found off;
-
-        tcp_nodelay off;
-        ## Set the OS file cache.
-        open_file_cache max=3000 inactive=120s;
-        open_file_cache_valid 45s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
-
-        ## Fallback to shopware
-        ## comment in if needed
-        try_files $uri /shopware.php?controller=Media&action=fallback;
-    }
-
     index shopware.php index.php;
     try_files $uri $uri/ /shopware.php$is_args$args;
 }


### PR DESCRIPTION
Hi @bcremer,

thanks for your nginx configuration for Shopware!

I noticed that some rules don't work, e.g. /themes/Gruntfile.js is accessible via HTTP despite [it's restricted](https://github.com/bcremer/shopware-with-nginx/blob/master/global/shopware.conf#L45-L48).

The reason is there are another rules which are matched instead. [This non-regex rule](https://github.com/bcremer/shopware-with-nginx/blob/master/global/shopware.conf#L76) has higher priority than restricting regex one. Once it's matched, [another nested rule](https://github.com/bcremer/shopware-with-nginx/blob/master/global/shopware.conf#L100) is processed and file is sent to client before 

Moving all the rules out of nested `location /` solved the problem.

I'm not expert in nginx so I'd ask you before - those nested rules under `location /` have any special meaning (e.g. performance)?

Thank you!
Jaroslav
