### PR TITLE
use http 404 instead of deny for restricted locations

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -10,26 +10,24 @@ location = /favicon.ico {
     access_log off;
 }
 
-## Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
+## Deny all attempts to access hidden files such as .env, .htaccess, .htpasswd, .DS_Store (Mac).
 location ~ /\. {
-    deny all;
-    access_log off;
-    log_not_found off;
+    return 404;
 }
 
 ## Deny all attems to access possible configuration files
 location ~ \.(tpl|yml|ini|log)$ {
-    deny all;
+    return 404;
 }
 
 ## Deny access to media upload folder
 location ^~ /media/temp/ {
-    deny all;
+    return 404;
 }
 
 # Shopware caches and logs
 location ^~ /var/ {
-    deny all;
+    return 404;
 }
 
 # Deny access to root files
@@ -48,7 +46,7 @@ location ~ /themes/(.*)(.*\.lock|package\.json|Gruntfile\.js|all\.less)$ {
 }
 
 location ^~ /files/documents/ {
-    deny all;
+    return 404;
 }
 
 # Block direct access to ESDs, but allow the follwing download options:


### PR DESCRIPTION
this is a proposal to harmonize the restrictions with the other deny-location blocks, already making use of a 404 status - and make it more robust and foolproof.

I stumbled on this with shopware 5.4 usage of a dotenv file. In development setups for sharing with trusted parties, an auth_basic or some ip allow is used. With the nested "deny all" via include file, the parent server{} declaring a satisfy all/any, those paths will be accessible for those fulfilling the criteria(s). Though this is of no concern in a production setup, this is a minor pitfall in development.

I've come to the conclusion a return 403 (or even a 404, as the rfc [suggests](https://tools.ietf.org/html/rfc2616#section-10.4.4) for purposes of no information disclosure) is less error prone if I know the ressource should under no circumstances be accessed via http, even if "authenticated" in a general context.