### PR TITLE
Add .webp extension to static files serve

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -96,7 +96,7 @@ location / {
 
 
     ## All static files will be served directly.
-    location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|html)$ {
+    location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|webp|html)$ {
         ## Defining rewrite rules
         rewrite files/documents/.* /engine last;
         rewrite backend/media/(.*) /media/$1 last;


### PR DESCRIPTION
Just add .webp extension to cache webp images properly. If you want to use for example https://github.com/shyim/ShyimWebP Shopware plugin.