### PR TITLE
Add access restriction for specific xml files in plugin dirs

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -49,6 +49,13 @@ location ^~ /files/documents/ {
     return 404;
 }
 
+# Restrict access to plugin xmls
+location ~ /custom/.*(config|menu|services|plugin)\.xml$ {
+    # rewrite, because this is the default behaviour for non-existing files and
+    # makes it difficult to detect whether a plugin is installed or not by checking the files
+    rewrite . /shopware.php?controller=Error&action=pageNotFoundError last;
+}
+
 # Block direct access to ESDs, but allow the follwing download options:
 #  * 'PHP' (slow)
 #  * 'X-Accel' (optimized)


### PR DESCRIPTION
Without this change it would be possible to access e.g. the config.xml of a plugin and this would cause a security vulnerability if the config-file contains sensitive data. 