### PR TITLE
Enable support for HTTP/2 Server Push

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -181,4 +181,8 @@ location ~ \.php$ {
 
     ## Set $fpm_upstream in your server block
     fastcgi_pass $fpm_upstream;
+
+    ## Support for HTTP/2 Server Push
+    ## Available in NGINX version 1.13.9 and up
+    # http2_push_preload on;
 }


### PR DESCRIPTION
Shopware 5.6 implements support for HTTP/2 Server Push of resources like CSS and JS files. To support this feature in NGINX it is necessary activate the `http2_push_preload` directive. Please see https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/ for details.