### PR TITLE
enable shopware cache invalidation via http BAN method

### DIFF
--- a/global/shopware.conf
+++ b/global/shopware.conf
@@ -5,6 +5,13 @@
 ## Please note that you need a PHP-FPM upstream configured in the http context, and its name set in the $fpm_upstream variable.
 ## https://github.com/bcremer/shopware-with-nginx
 
+# Nginx will not handle the BAN method on static paths, rewrite request to be handled by fastcgi.
+#  * customize 'purge_allowed_ips' in 'httpcache' section in config.php if request does not originate from localhost
+#  * make sure the requests aren't schema redirected. This will alter the method to GET and be defective
+if ($request_method = BAN) {
+    rewrite ^ /shopware.php last;
+}
+
 location = /favicon.ico {
     log_not_found off;
     access_log off;


### PR DESCRIPTION
Nginx won't handle BAN (or POST) on static resources and return a `405 Method Not Allowed`. In general, invalidation still works with `invalidateWithStore()`, but not via `invalidateWithBANRequest()`. See `invalidate()` in the [HttpCache Plugin](https://github.com/shopware5/shopware/blob/v5.5.4/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php#L792) when each is used.

Users will see a `Reverse proxy returned invalid status code` in their logs.

```
$ curl -sI -X BAN http://example.com/
HTTP/1.1 405 Not Allowed
Server: nginx
```

To forward the invalidation to PHP, a redirect to shopware.php is used, ending up being handled by fastcgi. According to [if-is-evil](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/), the use of `rewrite .. last` within `if` is declared "100% safe".

`last` will stop rewrite processing within the block and search for a new matching location, being `\.php$`.
```
if ($request_method = BAN) {
    rewrite ^ /shopware.php last;
}
```

PHP will handle the request and Nginx will return a 200
```
$ curl -sI -X BAN http://example.com/
HTTP/1.1 200 OK
Server: nginx
```

Invalidation now resets Age, prompts cache to re-fetch
```
$ curl -sI 'http://example.com/product-123'
HTTP/1.1 200 OK
...
Age: 5
X-Symfony-Cache: HEAD /product-123: fresh
...
$ curl --header 'x-shopware-invalidates: a123' -X BAN http://example.com/
$ curl -sI 'http://example.com/product-123'
HTTP/1.1 200 OK
...
X-Shopware-Cache-Id: ;a123;
...
Age: 0
X-Symfony-Cache: HEAD /product-123: miss, store
```

the example dump in the head of shopware.php verifies the internal nginx rewrite will not alter the method
```
print_r($_SERVER); die();
...
$ curl -s -X BAN 'http://example.com/' | grep BAN
    [REQUEST_METHOD] => BAN
```

Will very likely solve these issues:
[forum.shopware.com#35300](https://forum.shopware.com/discussion/35300/http-cache-invalidieren)
[forum.shopware.com#51742](https://forum.shopware.com/discussion/51742/cache-per-cli-invalidieren)
[forum.shopware.com#56593](https://forum.shopware.com/discussion/56593/http-cache-loeschen-ohne-auswirkungen)
[forum.shopware.com#56445](https://forum.shopware.com/discussion/56445/reverse-proxy-returned-invalid-status-code-when-trying-to-programmatically-clear-the-http-cache)

I commented extensively to avoid configuration errors, if you prefer to have it terse I'll remove the bullet points.